### PR TITLE
Add Directory.Build.props for shared build settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <ItemGroup>
+    <EditorConfigFiles Include=".editorconfig" Condition="Exists('.editorconfig')" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a Directory.Build.props file to centralize nullable, implicit using, and analyzer settings for all projects

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68caddef02b0832eb5ce8cba6fcb570e