### PR TITLE
Implement prompt schema API with layered architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Application environment configuration
+ASPNETCORE_ENVIRONMENT=Development
+
+# AI client configuration
+AI__ProviderName=simulated
+AI__Model=gpt-sim
+AI__RequestTimeout=00:00:05
+
+# Prompt dataset configuration
+PROMPTDATASETS__DATASETS__0__ID=sales-insights
+PROMPTDATASETS__DATASETS__0__PROMPT=Summarize the latest sales performance and highlight anomalies.
+PROMPTDATASETS__DATASETS__0__TABLES__0__NAME=orders
+PROMPTDATASETS__DATASETS__0__TABLES__0__DESCRIPTION=Customer purchases including totals and status
+PROMPTDATASETS__DATASETS__0__TABLES__0__COLUMNS__0__NAME=order_id
+PROMPTDATASETS__DATASETS__0__TABLES__0__COLUMNS__0__DATATYPE=uuid
+PROMPTDATASETS__DATASETS__0__TABLES__0__COLUMNS__0__DESCRIPTION=Unique order identifier
+# ... add additional columns/tables as needed following the same pattern

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore BazarBin.sln
+
+      - name: Lint
+        run: dotnet format --verify-no-changes
+
+      - name: Build
+        run: dotnet build BazarBin.sln --no-restore -c Release
+
+      - name: Test
+        run: dotnet test BazarBin.sln --no-build --configuration Release
+        env:
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 bin/
 obj/
+/TestResults/
+**/TestResults/
 /packages/
-riderModule.iml
-/_ReSharper.Caches/
+/.vs/
+.idea/
+*.user
+*.suo

--- a/BazarBin.Application/BazarBin.Application.csproj
+++ b/BazarBin.Application/BazarBin.Application.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BazarBin.Domain/BazarBin.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+</Project>

--- a/BazarBin.Application/Common/AppException.cs
+++ b/BazarBin.Application/Common/AppException.cs
@@ -1,0 +1,17 @@
+using System.Net;
+
+namespace BazarBin.Application.Common;
+
+public abstract class AppException : Exception
+{
+    protected AppException(string message, string errorCode, HttpStatusCode statusCode, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        ErrorCode = errorCode;
+        StatusCode = statusCode;
+    }
+
+    public string ErrorCode { get; }
+
+    public HttpStatusCode StatusCode { get; }
+}

--- a/BazarBin.Application/Common/ErrorCodes.cs
+++ b/BazarBin.Application/Common/ErrorCodes.cs
@@ -1,0 +1,8 @@
+namespace BazarBin.Application.Common;
+
+public static class ErrorCodes
+{
+    public const string DatasetIdRequired = "dataset_id_required";
+    public const string PromptDatasetNotFound = "prompt_dataset_not_found";
+    public const string SchemaNotFound = "schema_not_found";
+}

--- a/BazarBin.Application/Common/NotFoundException.cs
+++ b/BazarBin.Application/Common/NotFoundException.cs
@@ -1,0 +1,11 @@
+using System.Net;
+
+namespace BazarBin.Application.Common;
+
+public sealed class NotFoundException : AppException
+{
+    public NotFoundException(string message, string errorCode)
+        : base(message, errorCode, HttpStatusCode.NotFound)
+    {
+    }
+}

--- a/BazarBin.Application/Common/ValidationException.cs
+++ b/BazarBin.Application/Common/ValidationException.cs
@@ -1,0 +1,11 @@
+using System.Net;
+
+namespace BazarBin.Application.Common;
+
+public sealed class ValidationException : AppException
+{
+    public ValidationException(string message, string errorCode)
+        : base(message, errorCode, HttpStatusCode.BadRequest)
+    {
+    }
+}

--- a/BazarBin.Application/Prompts/Contracts/AiCompletionRequest.cs
+++ b/BazarBin.Application/Prompts/Contracts/AiCompletionRequest.cs
@@ -1,0 +1,17 @@
+namespace BazarBin.Application.Prompts.Contracts;
+
+public sealed class AiCompletionRequest
+{
+    public AiCompletionRequest(string datasetId, string prompt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+
+        DatasetId = datasetId;
+        Prompt = prompt;
+    }
+
+    public string DatasetId { get; }
+
+    public string Prompt { get; }
+}

--- a/BazarBin.Application/Prompts/Contracts/AiCompletionResponse.cs
+++ b/BazarBin.Application/Prompts/Contracts/AiCompletionResponse.cs
@@ -1,0 +1,21 @@
+namespace BazarBin.Application.Prompts.Contracts;
+
+public sealed class AiCompletionResponse
+{
+    public AiCompletionResponse(string datasetId, string prompt, string responseText)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseText);
+
+        DatasetId = datasetId;
+        Prompt = prompt;
+        ResponseText = responseText;
+    }
+
+    public string DatasetId { get; }
+
+    public string Prompt { get; }
+
+    public string ResponseText { get; }
+}

--- a/BazarBin.Application/Prompts/Contracts/GetPromptResponseRequest.cs
+++ b/BazarBin.Application/Prompts/Contracts/GetPromptResponseRequest.cs
@@ -1,0 +1,11 @@
+namespace BazarBin.Application.Prompts.Contracts;
+
+public sealed class GetPromptResponseRequest
+{
+    public GetPromptResponseRequest(string? datasetId)
+    {
+        DatasetId = datasetId ?? string.Empty;
+    }
+
+    public string DatasetId { get; }
+}

--- a/BazarBin.Application/Prompts/Contracts/GetPromptResponseResult.cs
+++ b/BazarBin.Application/Prompts/Contracts/GetPromptResponseResult.cs
@@ -1,0 +1,34 @@
+namespace BazarBin.Application.Prompts.Contracts;
+
+public sealed class GetPromptResponseResult
+{
+    public GetPromptResponseResult(
+        string datasetId,
+        string originalPrompt,
+        string finalPrompt,
+        string schemaComment,
+        string aiResponse)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(originalPrompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(finalPrompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaComment);
+        ArgumentException.ThrowIfNullOrWhiteSpace(aiResponse);
+
+        DatasetId = datasetId;
+        OriginalPrompt = originalPrompt;
+        FinalPrompt = finalPrompt;
+        SchemaComment = schemaComment;
+        AiResponse = aiResponse;
+    }
+
+    public string DatasetId { get; }
+
+    public string OriginalPrompt { get; }
+
+    public string FinalPrompt { get; }
+
+    public string SchemaComment { get; }
+
+    public string AiResponse { get; }
+}

--- a/BazarBin.Application/Prompts/GetPromptResponseHandler.cs
+++ b/BazarBin.Application/Prompts/GetPromptResponseHandler.cs
@@ -1,0 +1,62 @@
+using BazarBin.Application.Common;
+using BazarBin.Application.Prompts.Contracts;
+using BazarBin.Application.Schemas;
+using BazarBin.Domain.Prompts;
+using Microsoft.Extensions.Logging;
+
+namespace BazarBin.Application.Prompts;
+
+public sealed class GetPromptResponseHandler
+{
+    private readonly IPromptRepository promptRepository;
+    private readonly ITableSchemaProvider tableSchemaProvider;
+    private readonly ITableSchemaCommentBuilder tableSchemaCommentBuilder;
+    private readonly IAiClient aiClient;
+    private readonly ILogger<GetPromptResponseHandler> logger;
+
+    public GetPromptResponseHandler(
+        IPromptRepository promptRepository,
+        ITableSchemaProvider tableSchemaProvider,
+        ITableSchemaCommentBuilder tableSchemaCommentBuilder,
+        IAiClient aiClient,
+        ILogger<GetPromptResponseHandler> logger)
+    {
+        this.promptRepository = promptRepository;
+        this.tableSchemaProvider = tableSchemaProvider;
+        this.tableSchemaCommentBuilder = tableSchemaCommentBuilder;
+        this.aiClient = aiClient;
+        this.logger = logger;
+    }
+
+    public async Task<GetPromptResponseResult> HandleAsync(GetPromptResponseRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.DatasetId))
+        {
+            throw new ValidationException("Dataset id is required.", ErrorCodes.DatasetIdRequired);
+        }
+
+        logger.LogInformation("Fetching prompt for dataset {DatasetId}.", request.DatasetId);
+        PromptDataset? dataset = await promptRepository.GetByIdAsync(request.DatasetId, cancellationToken).ConfigureAwait(false);
+        if (dataset is null)
+        {
+            throw new NotFoundException($"Dataset '{request.DatasetId}' was not found.", ErrorCodes.PromptDatasetNotFound);
+        }
+
+        logger.LogInformation("Fetching table schema for dataset {DatasetId}.", dataset.Id);
+        var schema = await tableSchemaProvider.GetSchemaAsync(dataset.Id, cancellationToken).ConfigureAwait(false);
+        if (schema is null)
+        {
+            throw new NotFoundException($"Schema for dataset '{dataset.Id}' was not found.", ErrorCodes.SchemaNotFound);
+        }
+
+        var schemaComment = tableSchemaCommentBuilder.BuildComment(schema);
+        var finalPrompt = string.Join(Environment.NewLine + Environment.NewLine, schemaComment, dataset.Prompt);
+
+        logger.LogInformation("Sending composed prompt to AI client for dataset {DatasetId}.", dataset.Id);
+        var aiRequest = new AiCompletionRequest(dataset.Id, finalPrompt);
+        var completion = await aiClient.GetCompletionAsync(aiRequest, cancellationToken).ConfigureAwait(false);
+
+        return new GetPromptResponseResult(dataset.Id, dataset.Prompt, finalPrompt, schemaComment, completion.ResponseText);
+    }
+}

--- a/BazarBin.Application/Prompts/IAiClient.cs
+++ b/BazarBin.Application/Prompts/IAiClient.cs
@@ -1,0 +1,8 @@
+using BazarBin.Application.Prompts.Contracts;
+
+namespace BazarBin.Application.Prompts;
+
+public interface IAiClient
+{
+    Task<AiCompletionResponse> GetCompletionAsync(AiCompletionRequest request, CancellationToken cancellationToken);
+}

--- a/BazarBin.Application/Prompts/IPromptRepository.cs
+++ b/BazarBin.Application/Prompts/IPromptRepository.cs
@@ -1,0 +1,8 @@
+using BazarBin.Domain.Prompts;
+
+namespace BazarBin.Application.Prompts;
+
+public interface IPromptRepository
+{
+    Task<PromptDataset?> GetByIdAsync(string datasetId, CancellationToken cancellationToken);
+}

--- a/BazarBin.Application/Schemas/ITableSchemaCommentBuilder.cs
+++ b/BazarBin.Application/Schemas/ITableSchemaCommentBuilder.cs
@@ -1,0 +1,8 @@
+using BazarBin.Domain.Schemas;
+
+namespace BazarBin.Application.Schemas;
+
+public interface ITableSchemaCommentBuilder
+{
+    string BuildComment(TableSchema schema);
+}

--- a/BazarBin.Application/Schemas/ITableSchemaProvider.cs
+++ b/BazarBin.Application/Schemas/ITableSchemaProvider.cs
@@ -1,0 +1,8 @@
+using BazarBin.Domain.Schemas;
+
+namespace BazarBin.Application.Schemas;
+
+public interface ITableSchemaProvider
+{
+    Task<TableSchema?> GetSchemaAsync(string datasetId, CancellationToken cancellationToken);
+}

--- a/BazarBin.Application/Schemas/TableSchemaCommentBuilder.cs
+++ b/BazarBin.Application/Schemas/TableSchemaCommentBuilder.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using BazarBin.Domain.Schemas;
+
+namespace BazarBin.Application.Schemas;
+
+public sealed class TableSchemaCommentBuilder : ITableSchemaCommentBuilder
+{
+    public string BuildComment(TableSchema schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        var builder = new StringBuilder();
+        builder.AppendLine("/* Table Schema");
+        foreach (var table in schema.Tables)
+        {
+            builder.Append(" * Table: ").Append(table.Name);
+            if (!string.IsNullOrWhiteSpace(table.Description))
+            {
+                builder.Append(" - ").Append(table.Description);
+            }
+
+            builder.AppendLine();
+            foreach (var column in table.Columns)
+            {
+                builder.Append(" *   - ")
+                    .Append(column.Name)
+                    .Append(": ")
+                    .Append(column.DataType);
+                if (!string.IsNullOrWhiteSpace(column.Description))
+                {
+                    builder.Append(" (" + column.Description + ")");
+                }
+
+                builder.AppendLine();
+            }
+        }
+
+        builder.AppendLine(" */");
+        return builder.ToString().TrimEnd();
+    }
+}

--- a/BazarBin.Domain/BazarBin.Domain.csproj
+++ b/BazarBin.Domain/BazarBin.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BazarBin.Domain/Prompts/PromptDataset.cs
+++ b/BazarBin.Domain/Prompts/PromptDataset.cs
@@ -1,0 +1,17 @@
+namespace BazarBin.Domain.Prompts;
+
+public sealed class PromptDataset
+{
+    public PromptDataset(string id, string prompt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(prompt);
+
+        Id = id;
+        Prompt = prompt;
+    }
+
+    public string Id { get; }
+
+    public string Prompt { get; }
+}

--- a/BazarBin.Domain/Schemas/ColumnDefinition.cs
+++ b/BazarBin.Domain/Schemas/ColumnDefinition.cs
@@ -1,0 +1,20 @@
+namespace BazarBin.Domain.Schemas;
+
+public sealed class ColumnDefinition
+{
+    public ColumnDefinition(string name, string dataType, string? description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataType);
+
+        Name = name;
+        DataType = dataType;
+        Description = description;
+    }
+
+    public string Name { get; }
+
+    public string DataType { get; }
+
+    public string? Description { get; }
+}

--- a/BazarBin.Domain/Schemas/TableDefinition.cs
+++ b/BazarBin.Domain/Schemas/TableDefinition.cs
@@ -1,0 +1,20 @@
+namespace BazarBin.Domain.Schemas;
+
+public sealed class TableDefinition
+{
+    public TableDefinition(string name, string? description, IReadOnlyCollection<ColumnDefinition> columns)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        Name = name;
+        Description = description;
+        Columns = columns.ToArray();
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public IReadOnlyCollection<ColumnDefinition> Columns { get; }
+}

--- a/BazarBin.Domain/Schemas/TableSchema.cs
+++ b/BazarBin.Domain/Schemas/TableSchema.cs
@@ -1,0 +1,17 @@
+namespace BazarBin.Domain.Schemas;
+
+public sealed class TableSchema
+{
+    public TableSchema(string datasetId, IReadOnlyCollection<TableDefinition> tables)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        ArgumentNullException.ThrowIfNull(tables);
+
+        DatasetId = datasetId;
+        Tables = tables.ToArray();
+    }
+
+    public string DatasetId { get; }
+
+    public IReadOnlyCollection<TableDefinition> Tables { get; }
+}

--- a/BazarBin.Infrastructure/Ai/AiClientOptions.cs
+++ b/BazarBin.Infrastructure/Ai/AiClientOptions.cs
@@ -1,0 +1,12 @@
+namespace BazarBin.Infrastructure.Ai;
+
+public sealed class AiClientOptions
+{
+    public const string SectionName = "Ai";
+
+    public string ProviderName { get; init; } = "simulated";
+
+    public string Model { get; init; } = "mock";
+
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(10);
+}

--- a/BazarBin.Infrastructure/Ai/SimulatedAiClient.cs
+++ b/BazarBin.Infrastructure/Ai/SimulatedAiClient.cs
@@ -1,0 +1,32 @@
+using BazarBin.Application.Prompts;
+using BazarBin.Application.Prompts.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BazarBin.Infrastructure.Ai;
+
+public sealed class SimulatedAiClient : IAiClient
+{
+    private readonly IOptionsMonitor<AiClientOptions> optionsMonitor;
+    private readonly ILogger<SimulatedAiClient> logger;
+
+    public SimulatedAiClient(IOptionsMonitor<AiClientOptions> optionsMonitor, ILogger<SimulatedAiClient> logger)
+    {
+        this.optionsMonitor = optionsMonitor;
+        this.logger = logger;
+    }
+
+    public Task<AiCompletionResponse> GetCompletionAsync(AiCompletionRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var options = optionsMonitor.CurrentValue;
+        logger.LogInformation(
+            "Simulating AI response for dataset {DatasetId} using provider {Provider} and model {Model}.",
+            request.DatasetId,
+            options.ProviderName,
+            options.Model);
+
+        var responseText = $"Simulated answer from {options.ProviderName}:{options.Model} for dataset {request.DatasetId}.";
+        return Task.FromResult(new AiCompletionResponse(request.DatasetId, request.Prompt, responseText));
+    }
+}

--- a/BazarBin.Infrastructure/BazarBin.Infrastructure.csproj
+++ b/BazarBin.Infrastructure/BazarBin.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BazarBin.Application/BazarBin.Application.csproj" />
+    <ProjectReference Include="../BazarBin.Domain/BazarBin.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
+  </ItemGroup>
+</Project>

--- a/BazarBin.Infrastructure/Configuration/PromptDatasetsOptions.cs
+++ b/BazarBin.Infrastructure/Configuration/PromptDatasetsOptions.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace BazarBin.Infrastructure.Configuration;
+
+public sealed class PromptDatasetsOptions
+{
+    public const string SectionName = "PromptDatasets";
+
+    [Required]
+    public IList<PromptDatasetOptions> Datasets { get; init; } = new List<PromptDatasetOptions>();
+}
+
+public sealed class PromptDatasetOptions
+{
+    [Required]
+    public string Id { get; init; } = string.Empty;
+
+    [Required]
+    public string Prompt { get; init; } = string.Empty;
+
+    [Required]
+    public IList<TableOptions> Tables { get; init; } = new List<TableOptions>();
+}
+
+public sealed class TableOptions
+{
+    [Required]
+    public string Name { get; init; } = string.Empty;
+
+    public string? Description { get; init; }
+
+    [Required]
+    public IList<ColumnOptions> Columns { get; init; } = new List<ColumnOptions>();
+}
+
+public sealed class ColumnOptions
+{
+    [Required]
+    public string Name { get; init; } = string.Empty;
+
+    [Required]
+    public string DataType { get; init; } = string.Empty;
+
+    public string? Description { get; init; }
+}

--- a/BazarBin.Infrastructure/Configuration/PromptDatasetsOptionsValidator.cs
+++ b/BazarBin.Infrastructure/Configuration/PromptDatasetsOptionsValidator.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Options;
+
+namespace BazarBin.Infrastructure.Configuration;
+
+public sealed class PromptDatasetsOptionsValidator : IValidateOptions<PromptDatasetsOptions>
+{
+    public ValidateOptionsResult Validate(string? name, PromptDatasetsOptions options)
+    {
+        if (options.Datasets.Count == 0)
+        {
+            return ValidateOptionsResult.Fail("At least one prompt dataset must be configured.");
+        }
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dataset in options.Datasets)
+        {
+            if (string.IsNullOrWhiteSpace(dataset.Id))
+            {
+                return ValidateOptionsResult.Fail("Dataset id cannot be empty.");
+            }
+
+            if (!ids.Add(dataset.Id))
+            {
+                return ValidateOptionsResult.Fail($"Duplicate dataset id '{dataset.Id}' detected.");
+            }
+
+            if (string.IsNullOrWhiteSpace(dataset.Prompt))
+            {
+                return ValidateOptionsResult.Fail($"Dataset '{dataset.Id}' must define a prompt.");
+            }
+
+            if (dataset.Tables.Count == 0)
+            {
+                return ValidateOptionsResult.Fail($"Dataset '{dataset.Id}' must define at least one table schema.");
+            }
+
+            foreach (var table in dataset.Tables)
+            {
+                if (string.IsNullOrWhiteSpace(table.Name))
+                {
+                    return ValidateOptionsResult.Fail($"Dataset '{dataset.Id}' contains a table with an empty name.");
+                }
+
+                if (table.Columns.Count == 0)
+                {
+                    return ValidateOptionsResult.Fail($"Table '{table.Name}' in dataset '{dataset.Id}' must contain at least one column.");
+                }
+
+                foreach (var column in table.Columns)
+                {
+                    if (string.IsNullOrWhiteSpace(column.Name))
+                    {
+                        return ValidateOptionsResult.Fail($"Table '{table.Name}' in dataset '{dataset.Id}' has a column with an empty name.");
+                    }
+
+                    if (string.IsNullOrWhiteSpace(column.DataType))
+                    {
+                        return ValidateOptionsResult.Fail($"Column '{column.Name}' in table '{table.Name}' must define a data type.");
+                    }
+                }
+            }
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/BazarBin.Infrastructure/DependencyInjection.cs
+++ b/BazarBin.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,38 @@
+using BazarBin.Application.Prompts;
+using BazarBin.Application.Schemas;
+using BazarBin.Infrastructure.Ai;
+using BazarBin.Infrastructure.Configuration;
+using BazarBin.Infrastructure.Prompts;
+using BazarBin.Infrastructure.Schemas;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace BazarBin.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddBazarBinInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<PromptDatasetsOptions>()
+            .Bind(configuration.GetSection(PromptDatasetsOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddSingleton<IValidateOptions<PromptDatasetsOptions>, PromptDatasetsOptionsValidator>();
+
+        services.AddOptions<AiClientOptions>()
+            .Bind(configuration.GetSection(AiClientOptions.SectionName))
+            .ValidateOnStart();
+
+        services.AddSingleton<IPromptRepository, ConfigurationPromptRepository>();
+        services.AddSingleton<ITableSchemaProvider, ConfigurationTableSchemaProvider>();
+        services.AddSingleton<ITableSchemaCommentBuilder, TableSchemaCommentBuilder>();
+        services.AddSingleton<IAiClient, SimulatedAiClient>();
+        services.AddScoped<GetPromptResponseHandler>();
+
+        return services;
+    }
+}

--- a/BazarBin.Infrastructure/Prompts/ConfigurationPromptRepository.cs
+++ b/BazarBin.Infrastructure/Prompts/ConfigurationPromptRepository.cs
@@ -1,0 +1,31 @@
+using BazarBin.Application.Prompts;
+using BazarBin.Domain.Prompts;
+using BazarBin.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace BazarBin.Infrastructure.Prompts;
+
+public sealed class ConfigurationPromptRepository : IPromptRepository
+{
+    private readonly IOptionsMonitor<PromptDatasetsOptions> options;
+
+    public ConfigurationPromptRepository(IOptionsMonitor<PromptDatasetsOptions> options)
+    {
+        this.options = options;
+    }
+
+    public Task<PromptDataset?> GetByIdAsync(string datasetId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        var dataset = options.CurrentValue.Datasets
+            .FirstOrDefault(x => string.Equals(x.Id, datasetId, StringComparison.OrdinalIgnoreCase));
+
+        if (dataset is null)
+        {
+            return Task.FromResult<PromptDataset?>(null);
+        }
+
+        var result = new PromptDataset(dataset.Id, dataset.Prompt);
+        return Task.FromResult<PromptDataset?>(result);
+    }
+}

--- a/BazarBin.Infrastructure/Schemas/ConfigurationTableSchemaProvider.cs
+++ b/BazarBin.Infrastructure/Schemas/ConfigurationTableSchemaProvider.cs
@@ -1,0 +1,38 @@
+using BazarBin.Application.Schemas;
+using BazarBin.Domain.Schemas;
+using BazarBin.Infrastructure.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace BazarBin.Infrastructure.Schemas;
+
+public sealed class ConfigurationTableSchemaProvider : ITableSchemaProvider
+{
+    private readonly IOptionsMonitor<PromptDatasetsOptions> options;
+
+    public ConfigurationTableSchemaProvider(IOptionsMonitor<PromptDatasetsOptions> options)
+    {
+        this.options = options;
+    }
+
+    public Task<TableSchema?> GetSchemaAsync(string datasetId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(datasetId);
+        var dataset = options.CurrentValue.Datasets
+            .FirstOrDefault(x => string.Equals(x.Id, datasetId, StringComparison.OrdinalIgnoreCase));
+
+        if (dataset is null)
+        {
+            return Task.FromResult<TableSchema?>(null);
+        }
+
+        var tables = dataset.Tables
+            .Select(table => new TableDefinition(
+                table.Name,
+                table.Description,
+                table.Columns.Select(column => new ColumnDefinition(column.Name, column.DataType, column.Description)).ToArray()))
+            .ToArray();
+
+        var schema = new TableSchema(dataset.Id, tables);
+        return Task.FromResult<TableSchema?>(schema);
+    }
+}

--- a/BazarBin.Mcp.Server/BazarBin.Mcp.Server.csproj
+++ b/BazarBin.Mcp.Server/BazarBin.Mcp.Server.csproj
@@ -1,21 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="..\.dockerignore">
-        <Link>.dockerignore</Link>
-      </Content>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BazarBin.Application/BazarBin.Application.csproj" />
+    <ProjectReference Include="../BazarBin.Infrastructure/BazarBin.Infrastructure.csproj" />
+    <ProjectReference Include="../BazarBin.Domain/BazarBin.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\.dockerignore">
+      <Link>.dockerignore</Link>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/BazarBin.Mcp.Server/Contracts/PromptResponseDto.cs
+++ b/BazarBin.Mcp.Server/Contracts/PromptResponseDto.cs
@@ -1,0 +1,8 @@
+namespace BazarBin.Mcp.Server.Contracts;
+
+public sealed record PromptResponseDto(
+    string DatasetId,
+    string OriginalPrompt,
+    string SchemaComment,
+    string FinalPrompt,
+    string AiResponse);

--- a/BazarBin.Mcp.Server/Program.cs
+++ b/BazarBin.Mcp.Server/Program.cs
@@ -1,13 +1,79 @@
+using System.IO;
+using Asp.Versioning;
+using Asp.Versioning.Builder;
+using BazarBin.Application.Common;
+using BazarBin.Application.Prompts;
+using BazarBin.Application.Prompts.Contracts;
+using BazarBin.Infrastructure;
+using BazarBin.Mcp.Server.Contracts;
+using DotNetEnv;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+var localEnvPath = Path.Combine(AppContext.BaseDirectory, ".env");
+if (File.Exists(localEnvPath))
+{
+    Env.Load(localEnvPath);
+}
+else if (File.Exists(".env"))
+{
+    Env.Load();
+}
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Configuration.AddEnvironmentVariables();
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddApiVersioning(options =>
+    {
+        options.DefaultApiVersion = new ApiVersion(1, 0);
+        options.AssumeDefaultVersionWhenUnspecified = true;
+        options.ReportApiVersions = true;
+    })
+    .AddApiExplorer(options =>
+    {
+        options.GroupNameFormat = "'v'VVV";
+        options.SubstituteApiVersionInUrl = true;
+    });
+
+builder.Services.AddProblemDetails();
+builder.Services.AddBazarBinInfrastructure(builder.Configuration);
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+app.UseExceptionHandler(appBuilder =>
+{
+    appBuilder.Run(async context =>
+    {
+        var exceptionFeature = context.Features.Get<IExceptionHandlerFeature>();
+        var exception = exceptionFeature?.Error;
+
+        ProblemDetails problem = exception switch
+        {
+            AppException appException => new ProblemDetails
+            {
+                Status = (int)appException.StatusCode,
+                Title = "Request processing failed.",
+                Detail = appException.Message,
+                Extensions = { ["errorCode"] = appException.ErrorCode }
+            },
+            _ => new ProblemDetails
+            {
+                Status = StatusCodes.Status500InternalServerError,
+                Title = "Unexpected server error.",
+                Detail = "An unexpected error occurred while processing the request."
+            }
+        };
+
+        context.Response.StatusCode = problem.Status ?? StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/problem+json";
+        await context.Response.WriteAsJsonAsync(problem);
+    });
+});
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -16,29 +82,36 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
+ApiVersionSet versionSet = app.NewApiVersionSet()
+    .HasApiVersion(new ApiVersion(1, 0))
+    .ReportApiVersions()
+    .Build();
 
-app.MapGet("/weatherforecast", () =>
+var promptGroup = app.MapGroup("/api/v{version:apiVersion}/prompt")
+    .WithApiVersionSet(versionSet)
+    .HasApiVersion(1.0)
+    .WithTags("Prompt");
+
+promptGroup.MapGet("/{datasetId}", async Task<IResult> (
+        string datasetId,
+        GetPromptResponseHandler handler,
+        CancellationToken cancellationToken) =>
     {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
+        var result = await handler.HandleAsync(new GetPromptResponseRequest(datasetId), cancellationToken).ConfigureAwait(false);
+        var response = new PromptResponseDto(
+            result.DatasetId,
+            result.OriginalPrompt,
+            result.SchemaComment,
+            result.FinalPrompt,
+            result.AiResponse);
+        return TypedResults.Ok(response);
     })
-    .WithName("GetWeatherForecast")
+    .Produces<PromptResponseDto>(StatusCodes.Status200OK)
+    .ProducesProblem(StatusCodes.Status400BadRequest)
+    .ProducesProblem(StatusCodes.Status404NotFound)
+    .WithName("GetPromptByDatasetId")
     .WithOpenApi();
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
+public partial class Program;

--- a/BazarBin.Mcp.Server/appsettings.json
+++ b/BazarBin.Mcp.Server/appsettings.json
@@ -5,5 +5,41 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "PromptDatasets": {
+    "Datasets": [
+      {
+        "Id": "sales-insights",
+        "Prompt": "Summarize the latest sales performance and highlight anomalies.",
+        "Tables": [
+          {
+            "Name": "orders",
+            "Description": "Customer purchases including totals and status",
+            "Columns": [
+              { "Name": "order_id", "DataType": "uuid", "Description": "Unique order identifier" },
+              { "Name": "customer_id", "DataType": "uuid", "Description": "Customer placing the order" },
+              { "Name": "order_total", "DataType": "decimal", "Description": "Total order value" },
+              { "Name": "order_date", "DataType": "timestamp", "Description": "UTC time the order was created" },
+              { "Name": "status", "DataType": "text", "Description": "Current fulfillment status" }
+            ]
+          },
+          {
+            "Name": "order_items",
+            "Description": "Line items per order",
+            "Columns": [
+              { "Name": "order_id", "DataType": "uuid", "Description": "Foreign key to orders" },
+              { "Name": "sku", "DataType": "text", "Description": "Stock keeping unit" },
+              { "Name": "quantity", "DataType": "integer", "Description": "Units sold" },
+              { "Name": "unit_price", "DataType": "decimal", "Description": "Price per unit at time of sale" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Ai": {
+    "ProviderName": "simulated",
+    "Model": "gpt-sim",
+    "RequestTimeout": "00:00:05"
+  },
   "AllowedHosts": "*"
 }

--- a/BazarBin.Tests/Application/Prompts/GetPromptResponseHandlerTests.cs
+++ b/BazarBin.Tests/Application/Prompts/GetPromptResponseHandlerTests.cs
@@ -1,0 +1,99 @@
+using BazarBin.Application.Common;
+using BazarBin.Application.Prompts;
+using BazarBin.Application.Prompts.Contracts;
+using BazarBin.Application.Schemas;
+using BazarBin.Domain.Prompts;
+using BazarBin.Domain.Schemas;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace BazarBin.Tests.Application.Prompts;
+
+public sealed class GetPromptResponseHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenDatasetExists_ComposesPromptAndReturnsResponse()
+    {
+        var repository = Substitute.For<IPromptRepository>();
+        var schemaProvider = Substitute.For<ITableSchemaProvider>();
+        var commentBuilder = Substitute.For<ITableSchemaCommentBuilder>();
+        var aiClient = Substitute.For<IAiClient>();
+        var handler = new GetPromptResponseHandler(repository, schemaProvider, commentBuilder, aiClient, NullLogger<GetPromptResponseHandler>.Instance);
+
+        var dataset = new PromptDataset("sales", "Explain recent sales trends.");
+        var schema = new TableSchema("sales", new[]
+        {
+            new TableDefinition("orders", "", new[] { new ColumnDefinition("id", "uuid", "") })
+        });
+
+        repository.GetByIdAsync(dataset.Id, Arg.Any<CancellationToken>()).Returns(dataset);
+        schemaProvider.GetSchemaAsync(dataset.Id, Arg.Any<CancellationToken>()).Returns(schema);
+        commentBuilder.BuildComment(schema).Returns("/*schema*/");
+        aiClient.GetCompletionAsync(Arg.Any<AiCompletionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<AiCompletionRequest>();
+                return Task.FromResult(new AiCompletionResponse(request.DatasetId, request.Prompt, "response"));
+            });
+
+        var result = await handler.HandleAsync(new GetPromptResponseRequest(dataset.Id), CancellationToken.None);
+
+        result.DatasetId.Should().Be(dataset.Id);
+        result.SchemaComment.Should().Be("/*schema*/");
+        result.OriginalPrompt.Should().Be(dataset.Prompt);
+        result.FinalPrompt.Should().Be("/*schema*/\n\n" + dataset.Prompt);
+        result.AiResponse.Should().Be("response");
+
+        await aiClient.Received(1).GetCompletionAsync(Arg.Is<AiCompletionRequest>(r => r.Prompt == result.FinalPrompt), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDatasetNotFound_Throws()
+    {
+        var repository = Substitute.For<IPromptRepository>();
+        var schemaProvider = Substitute.For<ITableSchemaProvider>();
+        var commentBuilder = Substitute.For<ITableSchemaCommentBuilder>();
+        var aiClient = Substitute.For<IAiClient>();
+        var handler = new GetPromptResponseHandler(repository, schemaProvider, commentBuilder, aiClient, NullLogger<GetPromptResponseHandler>.Instance);
+
+        repository.GetByIdAsync("missing", Arg.Any<CancellationToken>()).Returns((PromptDataset?)null);
+
+        var act = () => handler.HandleAsync(new GetPromptResponseRequest("missing"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSchemaNotFound_Throws()
+    {
+        var repository = Substitute.For<IPromptRepository>();
+        var schemaProvider = Substitute.For<ITableSchemaProvider>();
+        var commentBuilder = Substitute.For<ITableSchemaCommentBuilder>();
+        var aiClient = Substitute.For<IAiClient>();
+        var handler = new GetPromptResponseHandler(repository, schemaProvider, commentBuilder, aiClient, NullLogger<GetPromptResponseHandler>.Instance);
+
+        var dataset = new PromptDataset("sales", "Explain recent sales trends.");
+        repository.GetByIdAsync(dataset.Id, Arg.Any<CancellationToken>()).Returns(dataset);
+        schemaProvider.GetSchemaAsync(dataset.Id, Arg.Any<CancellationToken>()).Returns((TableSchema?)null);
+
+        var act = () => handler.HandleAsync(new GetPromptResponseRequest(dataset.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDatasetIdMissing_ThrowsValidationException()
+    {
+        var repository = Substitute.For<IPromptRepository>();
+        var schemaProvider = Substitute.For<ITableSchemaProvider>();
+        var commentBuilder = Substitute.For<ITableSchemaCommentBuilder>();
+        var aiClient = Substitute.For<IAiClient>();
+        var handler = new GetPromptResponseHandler(repository, schemaProvider, commentBuilder, aiClient, NullLogger<GetPromptResponseHandler>.Instance);
+
+        var act = () => handler.HandleAsync(new GetPromptResponseRequest(" "), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+}

--- a/BazarBin.Tests/Application/Schemas/TableSchemaCommentBuilderTests.cs
+++ b/BazarBin.Tests/Application/Schemas/TableSchemaCommentBuilderTests.cs
@@ -1,0 +1,57 @@
+using BazarBin.Application.Schemas;
+using BazarBin.Domain.Schemas;
+using FluentAssertions;
+using Xunit;
+
+namespace BazarBin.Tests.Application.Schemas;
+
+public sealed class TableSchemaCommentBuilderTests
+{
+    [Fact]
+    public void BuildComment_ReturnsFormattedSchema()
+    {
+        var schema = new TableSchema(
+            "sales",
+            new[]
+            {
+                new TableDefinition(
+                    "orders",
+                    "Order header data",
+                    new[]
+                    {
+                        new ColumnDefinition("order_id", "uuid", "Primary key"),
+                        new ColumnDefinition("total", "decimal", null!)
+                    }),
+                new TableDefinition(
+                    "order_items",
+                    null,
+                    new[]
+                    {
+                        new ColumnDefinition("order_id", "uuid", "Foreign key"),
+                        new ColumnDefinition("sku", "text", "Item sku")
+                    })
+            });
+
+        var builder = new TableSchemaCommentBuilder();
+
+        var comment = builder.BuildComment(schema);
+
+        comment.Should().StartWith("/* Table Schema");
+        comment.Should().Contain("Table: orders - Order header data");
+        comment.Should().Contain("- order_id: uuid (Primary key)");
+        comment.Should().Contain("- total: decimal");
+        comment.Should().Contain("Table: order_items");
+        comment.Should().Contain("- sku: text (Item sku)");
+        comment.Should().EndWith("*/");
+    }
+
+    [Fact]
+    public void BuildComment_WhenSchemaIsNull_Throws()
+    {
+        var builder = new TableSchemaCommentBuilder();
+
+        var act = () => builder.BuildComment(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/BazarBin.Tests/BazarBin.Tests.csproj
+++ b/BazarBin.Tests/BazarBin.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BazarBin.Application/BazarBin.Application.csproj" />
+    <ProjectReference Include="../BazarBin.Infrastructure/BazarBin.Infrastructure.csproj" />
+    <ProjectReference Include="../BazarBin.Mcp.Server/BazarBin.Mcp.Server.csproj" />
+    <ProjectReference Include="../BazarBin.Domain/BazarBin.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/BazarBin.Tests/Integration/PromptEndpointTests.cs
+++ b/BazarBin.Tests/Integration/PromptEndpointTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BazarBin.Mcp.Server;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace BazarBin.Tests.Integration;
+
+public sealed class PromptEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> factory;
+
+    public PromptEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        this.factory = factory;
+    }
+
+    [Fact]
+    public async Task GetPrompt_ReturnsComposedPrompt()
+    {
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var response = await client.GetAsync("/api/v1/prompt/sales-insights");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<PromptResponse>(new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        payload.Should().NotBeNull();
+        payload!.DatasetId.Should().Be("sales-insights");
+        payload.OriginalPrompt.Should().NotBeNullOrWhiteSpace();
+        payload.SchemaComment.Should().StartWith("/* Table Schema");
+        payload.FinalPrompt.Should().StartWith(payload.SchemaComment);
+        payload.FinalPrompt.Should().Contain(payload.OriginalPrompt);
+        payload.AiResponse.Should().Contain("simulated:gpt-sim", because: "the simulated client should echo provider info");
+    }
+
+    private sealed record PromptResponse(string DatasetId, string OriginalPrompt, string SchemaComment, string FinalPrompt, string AiResponse);
+}

--- a/BazarBin.sln
+++ b/BazarBin.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin", "BazarBin\BazarBin.csproj", "{7799988E-2376-4145-9B17-D3BC39008F43}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3E5475A4-905C-4BAA-A705-00A7AC9F1334}"
@@ -10,6 +11,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Mcp.Client", "BazarBin.Mcp.Client\BazarBin.Mcp.Client.csproj", "{B4FE346A-2EC4-4D86-9588-1013306103EC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Mcp.Server", "BazarBin.Mcp.Server\BazarBin.Mcp.Server.csproj", "{7791E5A3-C73D-416F-A1F4-491D8E6A789C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Domain", "BazarBin.Domain\BazarBin.Domain.csproj", "{4CD7A567-DEB1-4E0F-B494-6439C2594C5D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Application", "BazarBin.Application\BazarBin.Application.csproj", "{6876E659-8590-4BDA-A367-2D4C4901CB0C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Infrastructure", "BazarBin.Infrastructure\BazarBin.Infrastructure.csproj", "{8F79FEAC-5B59-4247-BFF1-9865DB824EDE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BazarBin.Tests", "BazarBin.Tests\BazarBin.Tests.csproj", "{574C71D3-A2A9-4647-87FE-323B3D6BD926}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,5 +38,21 @@ Global
 		{7791E5A3-C73D-416F-A1F4-491D8E6A789C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7791E5A3-C73D-416F-A1F4-491D8E6A789C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7791E5A3-C73D-416F-A1F4-491D8E6A789C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CD7A567-DEB1-4E0F-B494-6439C2594C5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CD7A567-DEB1-4E0F-B494-6439C2594C5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CD7A567-DEB1-4E0F-B494-6439C2594C5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CD7A567-DEB1-4E0F-B494-6439C2594C5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6876E659-8590-4BDA-A367-2D4C4901CB0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6876E659-8590-4BDA-A367-2D4C4901CB0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6876E659-8590-4BDA-A367-2D4C4901CB0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6876E659-8590-4BDA-A367-2D4C4901CB0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F79FEAC-5B59-4247-BFF1-9865DB824EDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F79FEAC-5B59-4247-BFF1-9865DB824EDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F79FEAC-5B59-4247-BFF1-9865DB824EDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F79FEAC-5B59-4247-BFF1-9865DB824EDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{574C71D3-A2A9-4647-87FE-323B3D6BD926}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{574C71D3-A2A9-4647-87FE-323B3D6BD926}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{574C71D3-A2A9-4647-87FE-323B3D6BD926}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{574C71D3-A2A9-4647-87FE-323B3D6BD926}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.SILENT:
+
+SOLUTION := BazarBin.sln
+
+restore:
+dotnet restore $(SOLUTION)
+
+build: restore
+dotnet build $(SOLUTION) --no-restore -c Release
+
+lint:
+dotnet format --verify-no-changes
+
+format:
+dotnet format
+
+start: build
+dotnet run --project BazarBin.Mcp.Server/BazarBin.Mcp.Server.csproj --no-build --urls http://0.0.0.0:5000
+
+start-dev:
+dotnet run --project BazarBin.Mcp.Server/BazarBin.Mcp.Server.csproj --no-build
+
+coverage:
+dotnet test $(SOLUTION) --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults
+echo "Coverage results available under ./TestResults"
+test -f TestResults/**/coverage.cobertura.xml && echo "Cobertura report generated" || true
+
+TEST_ARGS ?=
+
+test: restore
+dotnet test $(SOLUTION) --no-build --configuration Release $(TEST_ARGS)
+
+.PHONY: restore build lint format start start-dev coverage test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+/*
+Quickstart:
+- make restore
+- make build
+- make test
+
+Assumptions:
+- Simulated AI client is acceptable for local development.
+- Prompt datasets are stored in configuration and can be overridden via environment variables.
+
+Limitations:
+- AI client is a stub and does not call an external provider.
+- Only a single sample dataset is bundled by default.
+*/
+# BazarBin MCP Server
+
+## Overview
+
+This solution provides a layered, testable .NET 8 API that serves AI-ready prompts enriched with reusable table schema metadata. The `/api/v1/prompt/{datasetId}` endpoint composes dataset prompts with schema information and returns simulated AI responses.
+
+## Project Structure
+
+- `BazarBin.Domain` – domain models for prompts and table schemas.
+- `BazarBin.Application` – use-cases, contracts, and abstractions.
+- `BazarBin.Infrastructure` – configuration-backed repositories, schema providers, and AI client implementations.
+- `BazarBin.Mcp.Server` – Fast minimal API host with versioning and problem details.
+- `BazarBin.Tests` – unit and integration tests using xUnit, FluentAssertions, and NSubstitute.
+
+## Scripts
+
+Use the provided `Makefile` for common workflows:
+
+- `make restore` – Restore NuGet dependencies.
+- `make build` – Build all projects.
+- `make test` – Run unit and integration tests with coverage.
+- `make lint` – Run formatting checks.
+- `make format` – Apply formatting.
+- `make start` – Launch the API locally.
+
+## Configuration
+
+Configuration follows the 12-factor pattern and can be supplied via `appsettings*.json` or environment variables. Copy `.env.example` to `.env` to override defaults locally.
+
+## Running Locally
+
+```bash
+make restore
+make build
+make start
+```
+
+Swagger UI is available at `https://localhost:5001/swagger` in development.
+
+## Testing
+
+```bash
+make test
+```
+
+## CI
+
+GitHub Actions workflow in `.github/workflows/ci.yml` runs lint, build, and tests on every push.
+
+## API Contract
+
+### `GET /api/v1/prompt/{datasetId}`
+
+Response body:
+
+```json
+{
+  "datasetId": "sales-insights",
+  "originalPrompt": "Summarize the latest sales performance and highlight anomalies.",
+  "schemaComment": "/* Table Schema ... */",
+  "finalPrompt": "/* Table Schema ... */\n\nSummarize ...",
+  "aiResponse": "Simulated answer from simulated:gpt-sim for dataset sales-insights."
+}
+```
+
+Errors follow RFC 7807 `application/problem+json` with an `errorCode` extension.
+
+## Limitations & Future Work
+
+- Replace the simulated AI client with an HTTP-based implementation using retry policies.
+- Extend schema support to load from external metadata services.
+- Add authentication and rate limiting for production environments.


### PR DESCRIPTION
## Summary
- introduce domain, application, and infrastructure projects for prompt datasets, schema formatting, and simulated AI completions
- add versioned minimal API endpoint `/api/v1/prompt/{datasetId}` that prefixes prompts with reusable table schema metadata and returns AI responses
- document workflows, provide env/sample configuration, CI pipeline, and comprehensive unit plus integration test coverage

## Testing
- dotnet test BazarBin.sln --no-build --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68cb0f1c8bb8832e978602c5ada4a1ba